### PR TITLE
CVSB-10074 Enabled test types for all axles in all nested categories

### DIFF
--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -1677,7 +1677,12 @@
           2,
           3,
           4,
-          5
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
         ],
         "nextTestTypesOrCategories": [
           {
@@ -2207,7 +2212,12 @@
           2,
           3,
           4,
-          5
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
         ],
         "nextTestTypesOrCategories": [
           {
@@ -2591,7 +2601,12 @@
       2,
       3,
       4,
-      5
+      5,
+      6,
+      7,
+      8,
+      9,
+      10
     ],
     "nextTestTypesOrCategories": [
       {
@@ -2608,7 +2623,12 @@
           2,
           3,
           4,
-          5
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
         ],
         "nextTestTypesOrCategories": [
           {
@@ -3043,7 +3063,12 @@
           2,
           3,
           4,
-          5
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
         ],
         "nextTestTypesOrCategories": [
           {
@@ -3060,7 +3085,12 @@
               2,
               3,
               4,
-              5
+              5,
+              6,
+              7,
+              8,
+              9,
+              10
             ],
             "nextTestTypesOrCategories": [
               {
@@ -3287,7 +3317,12 @@
               2,
               3,
               4,
-              5
+              5,
+              6,
+              7,
+              8,
+              9,
+              10
             ],
             "nextTestTypesOrCategories": [
               {
@@ -3516,7 +3551,12 @@
           2,
           3,
           4,
-          5
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
         ],
         "nextTestTypesOrCategories": [
           {


### PR DESCRIPTION
This bugfix will be merged and tested on CVSB-8109.

The call to the test-types backend retrieves the whole test-types file. The filtering on test categories is done on the front-end, therefore these sub-categories were not showing up in the app.