### PR TITLE
feat(vta-298): updated JSON to reflect PSV LEC taxonomy change

### DIFF
--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -1339,6 +1339,14 @@
         ]
       },
       {
+        "forVehicleAxles": null,
+        "forEuVehicleCategory": null,
+        "forVehicleClass": null,
+        "forVehicleSubclass": null,
+        "forVehicleWheels": null,
+        "forVehicleConfiguration": ["articulated", "rigid"],
+        "forVehicleSize": null,
+        "forVehicleType": ["psv"],
         "id": "39",
         "sortId": "39",
         "linkedIds": [
@@ -1366,28 +1374,112 @@
           "93"
         ],
         "name": "LEC",
-        "testTypeName": "Low Emissions Certificate (LEC) with annual test",
-        "forVehicleType": ["psv"],
-        "forVehicleSize": null,
-        "forVehicleConfiguration": ["articulated", "rigid"],
-        "forVehicleAxles": null,
-        "forEuVehicleCategory": null,
-        "forVehicleClass": null,
-        "forVehicleSubclass": null,
-        "forVehicleWheels": null,
-        "testTypeClassification": "NON ANNUAL",
-        "testCodes": [
+        "nextTestTypesOrCategories": [
           {
-            "forVehicleType": "psv",
-            "forVehicleSize": null,
-            "forVehicleConfiguration": ["articulated", "rigid"],
             "forVehicleAxles": null,
             "forEuVehicleCategory": null,
             "forVehicleClass": null,
             "forVehicleSubclass": null,
             "forVehicleWheels": null,
-            "defaultTestCode": "lbp",
-            "linkedTestCode": "lcp"
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleSize": null,
+            "forVehicleType": "psv",
+            "id": "200",
+            "sortId": "200",
+            "linkedIds": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "10",
+              "14",
+              "15",
+              "16",
+              "23",
+              "18",
+              "19",
+              "21",
+              "22",
+              "27",
+              "28",
+              "38",
+              "92",
+              "93"
+            ],
+            "name": "With linked test",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": null,
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "lcp",
+                "linkedTestCode": null
+              }
+            ],
+            "testTypeClassification": "NON ANNUAL",
+            "testTypeName": "Low Emissions Certificate (LEC) with annual test"
+          },
+          {
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleSize": null,
+            "forVehicleType": "psv",
+            "id": "201",
+            "sortId": "201",
+            "linkedIds": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "10",
+              "14",
+              "15",
+              "16",
+              "23",
+              "18",
+              "19",
+              "21",
+              "22",
+              "27",
+              "28",
+              "38",
+              "92",
+              "93"
+            ],
+            "name": "Without linked test",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": null,
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "lbp",
+                "linkedTestCode": null
+              }
+            ],
+            "testTypeClassification": "NON ANNUAL",
+            "testTypeName": "Low Emissions Certificate (LEC)"
           }
         ]
       }


### PR DESCRIPTION
## Linked LEC tests

Currently in PSV, when a VSA is selecting a Technical- LEC Test type, LEC Test with Annual Test is automatically added in the Technical test type with no option for VSA to go for Technical LEC Test to be done only.

[Link to VTA-298](https://jira.dvsacloud.uk/browse/VTA-298)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
