### PR TITLE
feat(cb2-4089): ability to return testTypeName and name fields

### DIFF
--- a/docs/test-types-api.yml
+++ b/docs/test-types-api.yml
@@ -34,11 +34,12 @@ paths:
               - vta
               - vtm
               - all
-            description: >-
-              It is used to filter testTypes by forVtmOnly attribute.
-              vta - Returns all testTypes where forVtmOnly = false
-              vtm - Returns all testTypes where forVtmOnly = true
-              all - Returns all testTypes without any filterƒå
+          description: >-
+            NOTE: NOT CURRENTLY IMPLEMENTED
+          # It is used to filter testTypes by forVtmOnly attribute.
+          # vta - Returns all testTypes where forVtmOnly = false
+          # vtm - Returns all testTypes where forVtmOnly = true
+          # all - Returns all testTypes without any filter
       operationId: getTestTypes
       responses:
         "200":
@@ -69,12 +70,17 @@ paths:
           required: true
         - in: query
           name: fields
+          explode: false
           schema:
-            type: string
-            enum:
-              - testTypeClassification
-              - defaultTestCode
-              - linkedTestCode
+            type: array
+            items:
+              type: string
+              enum:
+                - testTypeClassification
+                - defaultTestCode
+                - linkedTestCode
+                - name
+                - testTypeName
           required: true
         - in: query
           name: vehicleType
@@ -185,6 +191,7 @@ components:
     testType:
       type: object
       description: Test type
+      required: ["id", "forVehicleType", "name"]
       properties:
         id:
           type: string
@@ -299,6 +306,7 @@ components:
       description: >-
         A category that can be composed of zero/more categories + one/more test
         types
+      required: ["id", "forVehicleType", "name"]
       properties:
         id:
           type: string
@@ -324,7 +332,7 @@ components:
               - trl
               - car
               - lgv
-              - motorcycle∂
+              - motorcycle
           description: This category is applying only to these vehicle types.
         forVtmOnly:
           type: boolean
@@ -381,10 +389,11 @@ components:
             This category is applying only to the vehicles with those number of wheels. The vehicle number of wheels should descend from its parent, but should not be necessarily the same. If the value is null then it means the category or test type is applicable to any number of wheels.
         nextTestTypesOrCategories:
           type: array
-          description: This is an array composed of TestTypeCateogries and/or TestTypes
+          description: This is an array composed of TestTypeCategories and/or TestTypes
           items:
             oneOf:
               - $ref: "#/components/schemas/testType"
+              - $ref: "#/components/schemas/testTypeCategory"
     testTypesTaxonomy:
       type: array
       items:
@@ -392,7 +401,6 @@ components:
           - $ref: "#/components/schemas/testType"
           - $ref: "#/components/schemas/testTypeCategory"
 security:
-  - ApiKeyAuth: []
   - OAuth2:
       - read
       - write

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "start": "BRANCH=local serverless offline start",
+    "build-start": "npm run build && npm run start",
     "debug": "SLS_DEBUG=* BRANCH=local node --inspect ./node_modules/serverless/bin/serverless offline start",
     "build": "node_modules/typescript/bin/tsc --rootDir ./ --outDir .build --sourceMap false && npm run build:copy",
     "build:copy": "find src -type f \\( -name \"*.yml\" -or -name \"*.json\" \\) | cpio -pdm .build && find tests -type f \\( -name \"*.yml\" -or -name \"*.json\" \\)  | cpio -pdm .build",

--- a/src/functions/getTestTypesById.ts
+++ b/src/functions/getTestTypesById.ts
@@ -20,7 +20,7 @@ export const getTestTypesById: Handler = (event, context, callback) => {
     .keys({
       fields: Joi.string()
         .regex(
-          /^(testTypeClassification|defaultTestCode|linkedTestCode),?\s*((testTypeClassification|defaultTestCode|linkedTestCode),?\s*)?((testTypeClassification|defaultTestCode|linkedTestCode),?\s*)?$/
+          /^((testTypeClassification|defaultTestCode|linkedTestCode|name|testTypeName),?\s*)*$/
         )
         .required(),
       vehicleType: Joi.string().only(Object.values(ForVehicleType)).required(),

--- a/src/models/ILogMessage.ts
+++ b/src/models/ILogMessage.ts
@@ -1,5 +1,5 @@
 export interface ILogMessage {
-    HTTP?: string;
-    PATH_PARAMS?: string;
-    QUERY_PARAMS?: string;
+  HTTP?: string;
+  PATH_PARAMS?: string;
+  QUERY_PARAMS?: string;
 }

--- a/src/services/TestTypesService.ts
+++ b/src/services/TestTypesService.ts
@@ -143,17 +143,30 @@ export class TestTypesService {
           id: testType.id,
         };
 
-        filterExpression.fields // Iterate through filterExpression's fields and populate them in the response
-          .forEach((field: keyof TestCode) => {
-            response[field] = testCodes[0][field];
-          });
-
         // Populating testTypeClassification that is found in testType, not testCode
-        if (filterExpression.fields.includes("testTypeClassification")) {
-          response.testTypeClassification = testType.testTypeClassification;
-        }
+        this.addFieldsToResponse(
+          testType,
+          testCodes[0],
+          filterExpression.fields,
+          response
+        );
         return response;
       });
+  }
+
+  public addFieldsToResponse(
+    testType: ITestType,
+    testCode: TestCode,
+    fields: string[],
+    response: any
+  ): void {
+    fields.forEach((field) => {
+      if (testCode.hasOwnProperty(field)) {
+        response[field] = testCode[field as keyof TestCode];
+      } else if (testType.hasOwnProperty(field)) {
+        response[field] = testType[field as keyof ITestType];
+      }
+    });
   }
 
   /**

--- a/tests/unit/testTypesService.unitTest.ts
+++ b/tests/unit/testTypesService.unitTest.ts
@@ -5,6 +5,7 @@ import { ERRORS, HTTPRESPONSE } from "../../src/assets/Enums";
 import {
   ForEuVehicleCategory,
   ForVehicleSubclass,
+  ITestType,
   TestCode,
 } from "../../src/models/ITestType";
 
@@ -105,18 +106,109 @@ describe("when database is on", () => {
 
       context("testTypeClassification not requested", () => {
         it("returns id  and requested fields, without testTypeClassification", async () => {
-          expect.assertions(4);
+          testTypesService.findTestType = jest.fn().mockReturnValue({
+            id: "1",
+            name: "foo",
+            testTypeName: "bar",
+            testTypeClassification: "class1",
+            testCodes: [
+              {
+                forVehicleType: "psv",
+                forVehicleSize: "small",
+                forVehicleConfiguration: "rigid",
+                defaultTestCode: "foobar",
+                linkedTestCode: "foo",
+              },
+              {
+                forVehicleType: "psv",
+                forVehicleSize: "large",
+                forVehicleConfiguration: "rigid",
+                defaultTestCode: "foo",
+                linkedTestCode: "bar",
+              },
+            ],
+          });
+          expect.assertions(6);
           const output = await testTypesService.getTestTypesById("1", {
-            fields: ["defaultTestCode", "linkedTestCode"],
+            fields: [
+              "defaultTestCode",
+              "linkedTestCode",
+              "name",
+              "testTypeName",
+            ],
             vehicleType: "psv",
             vehicleSize: "small",
             vehicleConfiguration: "rigid",
           });
           const outputKeys = Object.keys(output);
-          expect(outputKeys).toContain("id");
-          expect(outputKeys).toContain("defaultTestCode");
-          expect(outputKeys).toContain("linkedTestCode");
+          expect(output.id).toEqual("1");
+          expect(output.defaultTestCode).toEqual("foobar");
+          expect(output.linkedTestCode).toEqual("foo");
+          expect(output.testTypeName).toEqual("bar");
+          expect(output.name).toEqual("foo");
           expect(outputKeys).not.toContain("testTypeClassification");
+        });
+      });
+
+      context("addFieldsToResponse", () => {
+        let testType: ITestType;
+        let testCode: TestCode;
+        let response: any;
+        beforeEach(() => {
+          testType = {
+            id: "1",
+            foo: "foo",
+          } as unknown as ITestType;
+          testCode = {
+            bar: "bar",
+          } as unknown as TestCode;
+          response = {
+            foobar: "foobar",
+          };
+        });
+        it("should add requested testCode fields to the response", () => {
+          const fields = ["foo"];
+          testTypesService.addFieldsToResponse(
+            testType,
+            testCode,
+            fields,
+            response
+          );
+          expect(response).toEqual({ foobar: "foobar", foo: "foo" });
+        });
+        it("should add requested testType fields to the response", () => {
+          const fields = ["bar"];
+          testTypesService.addFieldsToResponse(
+            testType,
+            testCode,
+            fields,
+            response
+          );
+          expect(response).toEqual({ foobar: "foobar", bar: "bar" });
+        });
+        it("should add requested testType and testCode fields to the response", () => {
+          const fields = ["bar", "foo"];
+          testTypesService.addFieldsToResponse(
+            testType,
+            testCode,
+            fields,
+            response
+          );
+          expect(response).toEqual({
+            foobar: "foobar",
+            bar: "bar",
+            foo: "foo",
+          });
+        });
+        it("should not add unknown fields to the response", () => {
+          const fields = ["bar", "baz"];
+          testTypesService.addFieldsToResponse(
+            testType,
+            testCode,
+            fields,
+            response
+          );
+          expect(response).toEqual({ foobar: "foobar", bar: "bar" });
         });
       });
 


### PR DESCRIPTION
## Amend Test Type

Ability to extract more properties from test types endpoint such as `name` and `testTypeName`. These will be used to update the `name` and `testTypeName`  fields when updating a test result in the `cvs-svc-test-results` lambda [in this function](https://github.com/dvsa/cvs-svc-test-results/blob/0b271753c0a52094c5e56bee888713b9957cdf75/src/handlers/VehicleTestController.ts#L301), which is only used by the `PUT` endpoint. 

PR for changes to the `cvs-svc-test-results`: https://github.com/dvsa/cvs-svc-test-results/pull/263

[CB2-4089](https://dvsa.atlassian.net/browse/CB2-4089)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number
