### PR TITLE
VTA-298: Linked LEC tests - PSV does not show without linked test

### DIFF
--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -11,7 +11,7 @@ export enum HTTPRESPONSE {
   AWS_EVENT_EMPTY = "AWS event is empty. Check your test event.",
   NOT_VALID_JSON = "Body is not a valid JSON.",
   RESOURCE_NOT_FOUND = "No resources match the search criteria.",
-  MISSING_PARAMETERS = "Missing parameter value."
+  MISSING_PARAMETERS = "Missing parameter value.",
 }
 
 export enum HTTPMethods {

--- a/src/functions/getTestTypesById.ts
+++ b/src/functions/getTestTypesById.ts
@@ -18,11 +18,16 @@ export const getTestTypesById: Handler = (event, context, callback) => {
   const check: Validator = new Validator();
 
   if (event.pathParameters) {
-      if (!check.parametersAreValid(event.pathParameters)) {
-            return Promise.resolve(new HTTPResponse(400, HTTPRESPONSE.MISSING_PARAMETERS));
-      }
+    if (!check.parametersAreValid(event.pathParameters)) {
+      return Promise.resolve(
+        new HTTPResponse(400, HTTPRESPONSE.MISSING_PARAMETERS)
+      );
+    }
   } else {
-      return Promise.resolve(new HTTPResponse(400, HTTPRESPONSE.MISSING_PARAMETERS));  }
+    return Promise.resolve(
+      new HTTPResponse(400, HTTPRESPONSE.MISSING_PARAMETERS)
+    );
+  }
   // Validate query parameters
   const queryParamSchema = Joi.object()
     .keys({

--- a/src/models/TestTypesDAO.ts
+++ b/src/models/TestTypesDAO.ts
@@ -31,9 +31,7 @@ export default class TestTypesDAO {
    * Get All test Types  in the DB
    * @returns ultimately, an array of TestTypes objects, wrapped in a PromiseResult, wrapped in a Promise
    */
-  public getAll(): Promise<
-    PromiseResult<DocumentClient.ScanOutput, AWSError>
-  > {
+  public getAll(): Promise<PromiseResult<DocumentClient.ScanOutput, AWSError>> {
     return TestTypesDAO.dbClient.scan({ TableName: this.tableName }).promise();
   }
 

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -1,26 +1,30 @@
 export class Validator {
-    // tslint:disable-next-line: no-empty
-    public constructor() {}
+  // tslint:disable-next-line: no-empty
+  public constructor() {}
 
-    /**
-     * Validate query or path parameter provided in the request
-     * @returns boolean Result of logic determining validity
-     * @param parameters This is expecting an object as a parameter
-     */
-    public parametersAreValid<T extends string>(parameters: T): boolean {
-        let isValid: boolean = true;
-        for (const key of Object.keys(parameters)) {
-            const value: string = Object.values(parameters)[key.indexOf(key)];
-            if (value) {
-                if (value.trim().length === 0 || value === "undefined" || value === "null") {
-                    isValid = false;
-                    break;
-                }
-            } else {
-                isValid = false;
-                break;
-            }
+  /**
+   * Validate query or path parameter provided in the request
+   * @returns boolean Result of logic determining validity
+   * @param parameters This is expecting an object as a parameter
+   */
+  public parametersAreValid<T extends string>(parameters: T): boolean {
+    let isValid: boolean = true;
+    for (const key of Object.keys(parameters)) {
+      const value: string = Object.values(parameters)[key.indexOf(key)];
+      if (value) {
+        if (
+          value.trim().length === 0 ||
+          value === "undefined" ||
+          value === "null"
+        ) {
+          isValid = false;
+          break;
         }
-        return isValid;
+      } else {
+        isValid = false;
+        break;
+      }
     }
+    return isValid;
+  }
 }

--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -2,7 +2,7 @@
   {
     "id": "1",
     "sortId": "1",
-    "linkedIds": ["38", "39"],
+    "linkedIds": ["38", "200"],
     "suggestedTestTypeIds": ["1", "7", "10"],
     "name": "Annual test",
     "testTypeName": "Annual test",
@@ -59,7 +59,7 @@
   {
     "id": "2",
     "sortId": "2",
-    "linkedIds": ["38", "39"],
+    "linkedIds": ["38", "200"],
     "name": "Class 6A",
     "forVehicleType": ["psv"],
     "forVehicleSize": ["small", "large"],
@@ -73,7 +73,7 @@
       {
         "id": "3",
         "sortId": "3",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "suggestedTestTypeIds": ["3", "4", "8"],
         "name": "Annual test",
         "testTypeName": "Class 6A seatbelt installation check (annual test)",
@@ -118,7 +118,7 @@
       {
         "id": "4",
         "sortId": "4",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "suggestedTestTypeIds": ["3", "4", "8"],
         "name": "First test",
         "testTypeName": "Class 6A seatbelt installation check (first test)",
@@ -165,7 +165,7 @@
   {
     "id": "5",
     "sortId": "3",
-    "linkedIds": ["38", "39"],
+    "linkedIds": ["38", "200"],
     "name": "Retest",
     "forVehicleType": ["psv"],
     "forVehicleSize": ["large", "small"],
@@ -179,7 +179,7 @@
       {
         "id": "6",
         "sortId": "6",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "name": "Paid retest",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -193,7 +193,7 @@
           {
             "id": "7",
             "sortId": "7",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Any PSV retest",
             "testTypeName": "Paid retest",
             "suggestedTestTypeDisplayName": "Paid annual retest",
@@ -249,7 +249,7 @@
           {
             "id": "8",
             "sortId": "8",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Class 6A retest (seatbelt installation check)",
             "testTypeName": "Paid retest with Class 6A seatbelt installation check",
             "suggestedTestTypeDisplayName": "Paid class 6A retest",
@@ -295,7 +295,7 @@
       {
         "id": "9",
         "sortId": "9",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "name": "Part paid retest",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -309,7 +309,7 @@
           {
             "id": "10",
             "sortId": "10",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Any PSV retest",
             "testTypeName": "Part-paid retest",
             "suggestedTestTypeDisplayName": "Part paid annual retest",
@@ -369,7 +369,7 @@
   {
     "id": "11",
     "sortId": "4",
-    "linkedIds": ["38", "39"],
+    "linkedIds": ["38", "200"],
     "name": "Prohibition clearance",
     "forVehicleType": ["psv"],
     "forVehicleSize": ["large", "small"],
@@ -383,7 +383,7 @@
       {
         "id": "12",
         "sortId": "12",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "name": "Any PSV",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -397,7 +397,7 @@
           {
             "id": "13",
             "sortId": "13",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Full inspection/ full fee",
             "forVehicleType": ["psv"],
             "forVehicleSize": ["large", "small"],
@@ -411,7 +411,7 @@
               {
                 "id": "14",
                 "sortId": "14",
-                "linkedIds": ["38", "39"],
+                "linkedIds": ["38", "200"],
                 "name": "With certification",
                 "testTypeName": "Paid prohibition clearance (full inspection with certificate)",
                 "forVehicleType": ["psv"],
@@ -453,7 +453,7 @@
               {
                 "id": "15",
                 "sortId": "15",
-                "linkedIds": ["38", "39"],
+                "linkedIds": ["38", "200"],
                 "name": "Without certification",
                 "testTypeName": "Paid prohibition clearance (full inspection without certificate)",
                 "forVehicleType": ["psv"],
@@ -497,7 +497,7 @@
           {
             "id": "16",
             "sortId": "16",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Full inspection/ part fee",
             "testTypeName": "Part-paid prohibition clearance (full inspection)",
             "forVehicleType": ["psv"],
@@ -539,7 +539,7 @@
           {
             "id": "23",
             "sortId": "23",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Part inspection/ part fee",
             "testTypeName": "Part-paid prohibition clearance (partial inspection)",
             "forVehicleType": ["psv"],
@@ -582,7 +582,7 @@
             "id": "24",
             "sortId": "24",
             "name": "PG9 retest",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "forVehicleType": ["psv"],
             "forVehicleSize": ["large", "small"],
             "forVehicleConfiguration": ["articulated", "rigid"],
@@ -595,7 +595,7 @@
               {
                 "id": "17",
                 "sortId": "17",
-                "linkedIds": ["38", "39"],
+                "linkedIds": ["38", "200"],
                 "name": "Paid",
                 "forVehicleType": ["psv"],
                 "forVehicleSize": ["large", "small"],
@@ -610,7 +610,7 @@
                     "id": "18",
                     "sortId": "18",
                     "name": "With certification",
-                    "linkedIds": ["38", "39"],
+                    "linkedIds": ["38", "200"],
                     "testTypeName": "Paid prohibition clearance (retest with certificate)",
                     "forVehicleType": ["psv"],
                     "forVehicleSize": ["large", "small"],
@@ -651,7 +651,7 @@
                   {
                     "id": "19",
                     "sortId": "19",
-                    "linkedIds": ["38", "39"],
+                    "linkedIds": ["38", "200"],
                     "name": "Without certification",
                     "testTypeName": "Paid prohibition clearance (retest without certificate)",
                     "forVehicleType": ["psv"],
@@ -695,7 +695,7 @@
               {
                 "id": "20",
                 "sortId": "20",
-                "linkedIds": ["38", "39"],
+                "linkedIds": ["38", "200"],
                 "name": "Part paid",
                 "forVehicleType": ["psv"],
                 "forVehicleSize": ["large", "small"],
@@ -710,7 +710,7 @@
                     "id": "21",
                     "sortId": "21",
                     "name": "With certification",
-                    "linkedIds": ["38", "39"],
+                    "linkedIds": ["38", "200"],
                     "testTypeName": "Part-paid prohibition clearance (retest with certificate)",
                     "forVehicleType": ["psv"],
                     "forVehicleSize": ["large", "small"],
@@ -751,7 +751,7 @@
                   {
                     "id": "22",
                     "sortId": "22",
-                    "linkedIds": ["38", "39"],
+                    "linkedIds": ["38", "200"],
                     "name": "Without certification",
                     "testTypeName": "Part-paid prohibition clearance (retest without certificate)",
                     "forVehicleType": ["psv"],
@@ -799,7 +799,7 @@
       {
         "id": "26",
         "sortId": "26",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "name": "Class 6A (seatbelt installation check)",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -813,7 +813,7 @@
           {
             "id": "27",
             "sortId": "27",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "Full inspection / full fee",
             "testTypeName": "Paid prohibition clearance with Class 6A seatbelt installation check (full inspection)",
             "forVehicleType": ["psv"],
@@ -855,7 +855,7 @@
           {
             "id": "28",
             "sortId": "28",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "PG9 retest",
             "testTypeName": "Prohibition clearance (retest with Class 6A seatbelt installation check)",
             "forVehicleType": ["psv"],
@@ -899,7 +899,7 @@
       {
         "id": "92",
         "sortId": "92",
-        "linkedIds": ["38", "39"],
+        "linkedIds": ["38", "200"],
         "name": "Class 6A (No seatbelt installation check)",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -913,7 +913,7 @@
           {
             "id": "93",
             "sortId": "93",
-            "linkedIds": ["38", "39"],
+            "linkedIds": ["38", "200"],
             "name": "PG9 retest",
             "testTypeName": "Prohibition clearance (retest without Class 6A seatbelt installation check)",
             "forVehicleType": ["psv"],
@@ -1259,7 +1259,7 @@
       "27",
       "28",
       "38",
-      "39",
+      "200",
       "92",
       "93"
     ],
@@ -1297,7 +1297,7 @@
           "22",
           "27",
           "28",
-          "39",
+          "200",
           "92",
           "93"
         ],

--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -2,7 +2,7 @@
   {
     "id": "1",
     "sortId": "1",
-    "linkedIds": ["38", "200"],
+    "linkedIds": ["38", "39"],
     "suggestedTestTypeIds": ["1", "7", "10"],
     "name": "Annual test",
     "testTypeName": "Annual test",
@@ -59,7 +59,7 @@
   {
     "id": "2",
     "sortId": "2",
-    "linkedIds": ["38", "200"],
+    "linkedIds": ["38", "39"],
     "name": "Class 6A",
     "forVehicleType": ["psv"],
     "forVehicleSize": ["small", "large"],
@@ -73,7 +73,7 @@
       {
         "id": "3",
         "sortId": "3",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "suggestedTestTypeIds": ["3", "4", "8"],
         "name": "Annual test",
         "testTypeName": "Class 6A seatbelt installation check (annual test)",
@@ -118,7 +118,7 @@
       {
         "id": "4",
         "sortId": "4",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "suggestedTestTypeIds": ["3", "4", "8"],
         "name": "First test",
         "testTypeName": "Class 6A seatbelt installation check (first test)",
@@ -165,7 +165,7 @@
   {
     "id": "5",
     "sortId": "3",
-    "linkedIds": ["38", "200"],
+    "linkedIds": ["38", "39"],
     "name": "Retest",
     "forVehicleType": ["psv"],
     "forVehicleSize": ["large", "small"],
@@ -179,7 +179,7 @@
       {
         "id": "6",
         "sortId": "6",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "name": "Paid retest",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -193,7 +193,7 @@
           {
             "id": "7",
             "sortId": "7",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Any PSV retest",
             "testTypeName": "Paid retest",
             "suggestedTestTypeDisplayName": "Paid annual retest",
@@ -249,7 +249,7 @@
           {
             "id": "8",
             "sortId": "8",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Class 6A retest (seatbelt installation check)",
             "testTypeName": "Paid retest with Class 6A seatbelt installation check",
             "suggestedTestTypeDisplayName": "Paid class 6A retest",
@@ -295,7 +295,7 @@
       {
         "id": "9",
         "sortId": "9",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "name": "Part paid retest",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -309,7 +309,7 @@
           {
             "id": "10",
             "sortId": "10",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Any PSV retest",
             "testTypeName": "Part-paid retest",
             "suggestedTestTypeDisplayName": "Part paid annual retest",
@@ -369,7 +369,7 @@
   {
     "id": "11",
     "sortId": "4",
-    "linkedIds": ["38", "200"],
+    "linkedIds": ["38", "39"],
     "name": "Prohibition clearance",
     "forVehicleType": ["psv"],
     "forVehicleSize": ["large", "small"],
@@ -383,7 +383,7 @@
       {
         "id": "12",
         "sortId": "12",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "name": "Any PSV",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -397,7 +397,7 @@
           {
             "id": "13",
             "sortId": "13",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Full inspection/ full fee",
             "forVehicleType": ["psv"],
             "forVehicleSize": ["large", "small"],
@@ -411,7 +411,7 @@
               {
                 "id": "14",
                 "sortId": "14",
-                "linkedIds": ["38", "200"],
+                "linkedIds": ["38", "39"],
                 "name": "With certification",
                 "testTypeName": "Paid prohibition clearance (full inspection with certificate)",
                 "forVehicleType": ["psv"],
@@ -453,7 +453,7 @@
               {
                 "id": "15",
                 "sortId": "15",
-                "linkedIds": ["38", "200"],
+                "linkedIds": ["38", "39"],
                 "name": "Without certification",
                 "testTypeName": "Paid prohibition clearance (full inspection without certificate)",
                 "forVehicleType": ["psv"],
@@ -497,7 +497,7 @@
           {
             "id": "16",
             "sortId": "16",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Full inspection/ part fee",
             "testTypeName": "Part-paid prohibition clearance (full inspection)",
             "forVehicleType": ["psv"],
@@ -539,7 +539,7 @@
           {
             "id": "23",
             "sortId": "23",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Part inspection/ part fee",
             "testTypeName": "Part-paid prohibition clearance (partial inspection)",
             "forVehicleType": ["psv"],
@@ -582,7 +582,7 @@
             "id": "24",
             "sortId": "24",
             "name": "PG9 retest",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "forVehicleType": ["psv"],
             "forVehicleSize": ["large", "small"],
             "forVehicleConfiguration": ["articulated", "rigid"],
@@ -595,7 +595,7 @@
               {
                 "id": "17",
                 "sortId": "17",
-                "linkedIds": ["38", "200"],
+                "linkedIds": ["38", "39"],
                 "name": "Paid",
                 "forVehicleType": ["psv"],
                 "forVehicleSize": ["large", "small"],
@@ -610,7 +610,7 @@
                     "id": "18",
                     "sortId": "18",
                     "name": "With certification",
-                    "linkedIds": ["38", "200"],
+                    "linkedIds": ["38", "39"],
                     "testTypeName": "Paid prohibition clearance (retest with certificate)",
                     "forVehicleType": ["psv"],
                     "forVehicleSize": ["large", "small"],
@@ -651,7 +651,7 @@
                   {
                     "id": "19",
                     "sortId": "19",
-                    "linkedIds": ["38", "200"],
+                    "linkedIds": ["38", "39"],
                     "name": "Without certification",
                     "testTypeName": "Paid prohibition clearance (retest without certificate)",
                     "forVehicleType": ["psv"],
@@ -695,7 +695,7 @@
               {
                 "id": "20",
                 "sortId": "20",
-                "linkedIds": ["38", "200"],
+                "linkedIds": ["38", "39"],
                 "name": "Part paid",
                 "forVehicleType": ["psv"],
                 "forVehicleSize": ["large", "small"],
@@ -710,7 +710,7 @@
                     "id": "21",
                     "sortId": "21",
                     "name": "With certification",
-                    "linkedIds": ["38", "200"],
+                    "linkedIds": ["38", "39"],
                     "testTypeName": "Part-paid prohibition clearance (retest with certificate)",
                     "forVehicleType": ["psv"],
                     "forVehicleSize": ["large", "small"],
@@ -751,7 +751,7 @@
                   {
                     "id": "22",
                     "sortId": "22",
-                    "linkedIds": ["38", "200"],
+                    "linkedIds": ["38", "39"],
                     "name": "Without certification",
                     "testTypeName": "Part-paid prohibition clearance (retest without certificate)",
                     "forVehicleType": ["psv"],
@@ -799,7 +799,7 @@
       {
         "id": "26",
         "sortId": "26",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "name": "Class 6A (seatbelt installation check)",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -813,7 +813,7 @@
           {
             "id": "27",
             "sortId": "27",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "Full inspection / full fee",
             "testTypeName": "Paid prohibition clearance with Class 6A seatbelt installation check (full inspection)",
             "forVehicleType": ["psv"],
@@ -855,7 +855,7 @@
           {
             "id": "28",
             "sortId": "28",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "PG9 retest",
             "testTypeName": "Prohibition clearance (retest with Class 6A seatbelt installation check)",
             "forVehicleType": ["psv"],
@@ -899,7 +899,7 @@
       {
         "id": "92",
         "sortId": "92",
-        "linkedIds": ["38", "200"],
+        "linkedIds": ["38", "39"],
         "name": "Class 6A (No seatbelt installation check)",
         "forVehicleType": ["psv"],
         "forVehicleSize": ["large", "small"],
@@ -913,7 +913,7 @@
           {
             "id": "93",
             "sortId": "93",
-            "linkedIds": ["38", "200"],
+            "linkedIds": ["38", "39"],
             "name": "PG9 retest",
             "testTypeName": "Prohibition clearance (retest without Class 6A seatbelt installation check)",
             "forVehicleType": ["psv"],
@@ -1259,7 +1259,8 @@
       "27",
       "28",
       "38",
-      "200",
+      "39",
+      "201",
       "92",
       "93"
     ],
@@ -1297,7 +1298,8 @@
           "22",
           "27",
           "28",
-          "200",
+          "39",
+          "201",
           "92",
           "93"
         ],
@@ -1348,8 +1350,8 @@
         "forVehicleConfiguration": ["articulated", "rigid"],
         "forVehicleSize": null,
         "forVehicleType": ["psv"],
-        "id": "39",
-        "sortId": "39",
+        "id": "200",
+        "sortId": "200",
         "linkedIds": [
           "1",
           "2",
@@ -1385,8 +1387,8 @@
             "forVehicleConfiguration": ["articulated", "rigid"],
             "forVehicleSize": null,
             "forVehicleType": "psv",
-            "id": "200",
-            "sortId": "200",
+            "id": "39",
+            "sortId": "39",
             "linkedIds": [
               "1",
               "2",

--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -1340,6 +1340,14 @@
         ]
       },
       {
+        "forVehicleAxles": null,
+        "forEuVehicleCategory": null,
+        "forVehicleClass": null,
+        "forVehicleSubclass": null,
+        "forVehicleWheels": null,
+        "forVehicleConfiguration": ["articulated", "rigid"],
+        "forVehicleSize": null,
+        "forVehicleType": ["psv"],
         "id": "39",
         "sortId": "39",
         "linkedIds": [
@@ -1367,28 +1375,112 @@
           "93"
         ],
         "name": "LEC",
-        "testTypeName": "Low Emissions Certificate (LEC) with annual test",
-        "forVehicleType": ["psv"],
-        "forVehicleSize": null,
-        "forVehicleConfiguration": ["articulated", "rigid"],
-        "forVehicleAxles": null,
-        "forEuVehicleCategory": null,
-        "forVehicleClass": null,
-        "forVehicleSubclass": null,
-        "forVehicleWheels": null,
-        "testTypeClassification": "NON ANNUAL",
-        "testCodes": [
+        "nextTestTypesOrCategories": [
           {
-            "forVehicleType": "psv",
-            "forVehicleSize": null,
-            "forVehicleConfiguration": ["articulated", "rigid"],
             "forVehicleAxles": null,
             "forEuVehicleCategory": null,
             "forVehicleClass": null,
             "forVehicleSubclass": null,
             "forVehicleWheels": null,
-            "defaultTestCode": "lbp",
-            "linkedTestCode": "lcp"
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleSize": null,
+            "forVehicleType": "psv",
+            "id": "200",
+            "sortId": "200",
+            "linkedIds": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "10",
+              "14",
+              "15",
+              "16",
+              "23",
+              "18",
+              "19",
+              "21",
+              "22",
+              "27",
+              "28",
+              "38",
+              "92",
+              "93"
+            ],
+            "name": "With linked test",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": null,
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "lcp",
+                "linkedTestCode": null
+              }
+            ],
+            "testTypeClassification": "NON ANNUAL",
+            "testTypeName": "Low Emissions Certificate (LEC) with annual test"
+          },
+          {
+            "forVehicleAxles": null,
+            "forEuVehicleCategory": null,
+            "forVehicleClass": null,
+            "forVehicleSubclass": null,
+            "forVehicleWheels": null,
+            "forVehicleConfiguration": ["articulated", "rigid"],
+            "forVehicleSize": null,
+            "forVehicleType": "psv",
+            "id": "201",
+            "sortId": "201",
+            "linkedIds": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "10",
+              "14",
+              "15",
+              "16",
+              "23",
+              "18",
+              "19",
+              "21",
+              "22",
+              "27",
+              "28",
+              "38",
+              "92",
+              "93"
+            ],
+            "name": "Without linked test",
+            "testCodes": [
+              {
+                "forVehicleType": "psv",
+                "forVehicleSize": null,
+                "forVehicleConfiguration": ["articulated", "rigid"],
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "defaultTestCode": "lbp",
+                "linkedTestCode": null
+              }
+            ],
+            "testTypeClassification": "NON ANNUAL",
+            "testTypeName": "Low Emissions Certificate (LEC)"
           }
         ]
       }

--- a/tests/unit/getTestTypesByIDFunction.unitTest.ts
+++ b/tests/unit/getTestTypesByIDFunction.unitTest.ts
@@ -3,7 +3,7 @@ import { TestTypesService } from "../../src/services/TestTypesService";
 import { Context } from "aws-lambda";
 import { HTTPResponse } from "../../src/models/HTTPResponse";
 import { HTTPError } from "../../src/models/HTTPError";
-import {HTTPRESPONSE} from "../../src/assets/Enums";
+import { HTTPRESPONSE } from "../../src/assets/Enums";
 
 describe("getTestTypesById Function", () => {
   // @ts-ignore
@@ -160,15 +160,15 @@ describe("getTestTypesById Function", () => {
       expect(result).toBeInstanceOf(HTTPResponse);
       expect(result.statusCode).toEqual(400);
       expect(result.body).toEqual(
-          JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
+        JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
       );
     });
   });
   context("with path params", () => {
     it("should trigger validation in function when id is null", async () => {
       TestTypesService.prototype.getTestTypesById = jest
-          .fn()
-          .mockResolvedValue("Success");
+        .fn()
+        .mockResolvedValue("Success");
       const myEvent = {
         httpMethod: "GET",
         path: "/test-types/1",
@@ -183,13 +183,13 @@ describe("getTestTypesById Function", () => {
       expect(result).toBeInstanceOf(HTTPResponse);
       expect(result.statusCode).toEqual(400);
       expect(result.body).toEqual(
-          JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
+        JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
       );
     });
     it("should trigger validation in function when id is undefined", async () => {
       TestTypesService.prototype.getTestTypesById = jest
-          .fn()
-          .mockResolvedValue("Success");
+        .fn()
+        .mockResolvedValue("Success");
       const myEvent = {
         httpMethod: "GET",
         path: "/test-types/1",
@@ -204,13 +204,13 @@ describe("getTestTypesById Function", () => {
       expect(result).toBeInstanceOf(HTTPResponse);
       expect(result.statusCode).toEqual(400);
       expect(result.body).toEqual(
-          JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
+        JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
       );
     });
     it("should trigger validation in function when id is an empty string", async () => {
       TestTypesService.prototype.getTestTypesById = jest
-          .fn()
-          .mockResolvedValue("Success");
+        .fn()
+        .mockResolvedValue("Success");
       const myEvent = {
         httpMethod: "GET",
         path: "/test-types/1",
@@ -225,7 +225,7 @@ describe("getTestTypesById Function", () => {
       expect(result).toBeInstanceOf(HTTPResponse);
       expect(result.statusCode).toEqual(400);
       expect(result.body).toEqual(
-          JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
+        JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
       );
     });
   });

--- a/tests/unit/getTestTypesFunction.unitTest.ts
+++ b/tests/unit/getTestTypesFunction.unitTest.ts
@@ -53,7 +53,7 @@ describe("getTestTypes function", () => {
         } = JSON.parse(output.body);
         expect(output.statusCode).toEqual(200);
         expect(id).toEqual("1");
-        expect(linkedIds).toEqual(["38", "39"]);
+        expect(linkedIds).toEqual(["38", "200"]);
         expect(suggestedTestTypeIds).toEqual(["1", "7", "10"]);
         expect(name).toEqual("Annual test");
         expect(testTypeName).toEqual("Annual test");

--- a/tests/unit/getTestTypesFunction.unitTest.ts
+++ b/tests/unit/getTestTypesFunction.unitTest.ts
@@ -53,7 +53,7 @@ describe("getTestTypes function", () => {
         } = JSON.parse(output.body);
         expect(output.statusCode).toEqual(200);
         expect(id).toEqual("1");
-        expect(linkedIds).toEqual(["38", "200"]);
+        expect(linkedIds).toEqual(["38", "39"]);
         expect(suggestedTestTypeIds).toEqual(["1", "7", "10"]);
         expect(name).toEqual("Annual test");
         expect(testTypeName).toEqual("Annual test");


### PR DESCRIPTION
## Linked LEC tests - PSV does not show without linked test

Changes made to test-type taxonomy to allow 'PSV LEC without linked test' to be selected as a test type. 
[VTA-298](https://dvsa.atlassian.net/browse/VTA-298)

* NB - PO's confirmed there was no specific test type id for 'PSV LEC without linked test', as a result it was agreed as part of this change that the PSV LEC codes would be created/updated. This now follows the same flow as HGV LEC.

Previously:
39 - PSV LEC with linked test

Now:
200 - PSV LEC with linked test
201 - PSV LEC without linked test

E-mail sent to BA's/PO's as this will need to be fed back to the business.

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [X] Squashed commit contains the JIRA ticket number
