### PR TITLE
fix(cb2-7533): add car and lgv to IVA DBA test

### DIFF
--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -9544,7 +9544,7 @@
         "linkedIds": null,
         "name": "IVA",
         "testTypeName": "IVA",
-        "forVehicleType": "hgv",
+        "forVehicleType": ["hgv", "car", "lgv"],
         "forVehicleSize": null,
         "forVehicleConfiguration": null,
         "forVehicleAxles": null,


### PR DESCRIPTION
## Amend a Light Vehicle DBA

fix the dba types to show IVA for car and lgv

[CB2-7533](https://dvsa.atlassian.net/browse/CB2-7533)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
