### PR TITLE
fix(cb2-7874): adds test type names for lgv dba group 5

### DIFF
--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -8655,9 +8655,15 @@
             "forVehicleClass": null,
             "forVehicleSubclass": null,
             "forVehicleWheels": null,
-            "testCodes": [
+            "nextTestTypesOrCategories": [
               {
-                "forVehicleType": "lgv",
+                "id": "439",
+                "sortId": "439",
+                "typeOfTest": "desk-based",
+                "linkedIds": null,
+                "name": "Declaration of Conformity for fitment of approved exhaust abatement device",
+                "testTypeName": "Declaration of Conformity for fitment of approved exhaust abatement device",
+                "forVehicleType": ["lgv"],
                 "forVehicleSize": null,
                 "forVehicleConfiguration": null,
                 "forVehicleAxles": null,
@@ -8665,8 +8671,50 @@
                 "forVehicleClass": null,
                 "forVehicleSubclass": null,
                 "forVehicleWheels": null,
-                "defaultTestCode": "lnz",
-                "linkedTestCode": null
+                "testCodes": [
+                  {
+                    "forVehicleType": "lgv",
+                    "forVehicleSize": null,
+                    "forVehicleConfiguration": null,
+                    "forVehicleAxles": null,
+                    "forEuVehicleCategory": null,
+                    "forVehicleClass": null,
+                    "forVehicleSubclass": null,
+                    "forVehicleWheels": null,
+                    "defaultTestCode": "lnz",
+                    "linkedTestCode": null
+                  }
+                ]
+              },
+              {
+                "id": "449",
+                "sortId": "449",
+                "typeOfTest": "desk-based",
+                "linkedIds": null,
+                "name": "Declaration of testing of approved exhaust abatement device",
+                "testTypeName": "Declaration of testing of approved exhaust abatement device",
+                "forVehicleType": ["lgv"],
+                "forVehicleSize": null,
+                "forVehicleConfiguration": null,
+                "forVehicleAxles": null,
+                "forEuVehicleCategory": null,
+                "forVehicleClass": null,
+                "forVehicleSubclass": null,
+                "forVehicleWheels": null,
+                "testCodes": [
+                  {
+                    "forVehicleType": "lgv",
+                    "forVehicleSize": null,
+                    "forVehicleConfiguration": null,
+                    "forVehicleAxles": null,
+                    "forEuVehicleCategory": null,
+                    "forVehicleClass": null,
+                    "forVehicleSubclass": null,
+                    "forVehicleWheels": null,
+                    "defaultTestCode": "lnz",
+                    "linkedTestCode": null
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
## Group 5 tests not showing in test taxonomy


[CB2-7874](https://dvsa.atlassian.net/browse/CB2-7874)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
