### PR TITLE
feat(cb2-9056): update to show first test retest for prov record

### DIFF
--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -2502,6 +2502,7 @@
     "forVehicleSize": null,
     "forVehicleConfiguration": null,
     "forVehicleAxles": null,
+    "forProvisionalStatus": true,
     "forEuVehicleCategory": [
       "m1",
       "m2",
@@ -3692,6 +3693,7 @@
         "name": "First test retest",
         "forVehicleType": ["hgv", "trl"],
         "forProvisionalStatus": true,
+        "forProvisionalStatusOnly": true,
         "forVehicleSize": null,
         "forVehicleConfiguration": null,
         "forVehicleAxles": [2, 3, 4, 5, 6, 7, 8, 9, 10],


### PR DESCRIPTION
## Make it harder to incorrectly select a first test / first test retest

Show retest -> first test retest in provisional records
Hide retest -> first test retest for current records

**Note**
By default all tests are shown for current records
if a test-type has `forProvisionalStatus` then it is also shown for provisional records
if a test-type has `forProvisionalStatusOnly` it is only shown for provisional records, not current.

The filter happens on VTM over [here](https://github.com/dvsa/cvs-app-vtm/blob/7056dbc7dfb684806726bcf1b530a22b531a5ba9/src/app/store/test-types/selectors/test-types.selectors.ts#L105)

[CB2-9056](https://dvsa.atlassian.net/browse/CB2-9056)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
