### PR TITLE
feat(CB2-11215): Update test type taxonomy to allow 3 wheels driven for ea2 contingency test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8575,9 +8575,9 @@
       }
     },
     "node_modules/@serverless/dashboard-plugin/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -14198,9 +14198,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -16799,9 +16799,9 @@
       }
     },
     "node_modules/foreground-child/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -18760,9 +18760,9 @@
       "dev": true
     },
     "node_modules/jest-changed-files/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -28171,9 +28171,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -29943,11 +29943,10 @@
       }
     },
     "node_modules/serverless-offline/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "tslint src/**/*.ts tests/**/*.ts -q",
     "format": "prettier --write .",
     "sonar-scanner": "sonar-scanner",
-    "audit": "npm audit --prod",
+    "audit": "npm audit --omit=dev",
     "package": "mkdir ${ZIP_NAME} && cp package.json package-lock.json ${ZIP_NAME}/ && cp -r .build/src/* ${ZIP_NAME}/ && cd ${ZIP_NAME} && npm ci --production && rm package.json package-lock.json && zip -qr ../${ZIP_NAME}.zip .",
     "tools-setup": "sls dynamodb install"
   },

--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -9086,7 +9086,7 @@
                     "forEuVehicleCategory": null,
                     "forVehicleClass": "2",
                     "forVehicleSubclass": null,
-                    "forVehicleWheels": [2, 3],
+                    "forVehicleWheels": [2, 3, 4],
                     "defaultTestCode": "ea2",
                     "linkedTestCode": null,
                     "forProvisionalStatus": true

--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -9086,7 +9086,7 @@
                     "forEuVehicleCategory": null,
                     "forVehicleClass": "2",
                     "forVehicleSubclass": null,
-                    "forVehicleWheels": 2,
+                    "forVehicleWheels": [2, 3],
                     "defaultTestCode": "ea2",
                     "linkedTestCode": null,
                     "forProvisionalStatus": true

--- a/tests/resources/test-types.json
+++ b/tests/resources/test-types.json
@@ -9086,7 +9086,7 @@
                     "forEuVehicleCategory": null,
                     "forVehicleClass": "2",
                     "forVehicleSubclass": null,
-                    "forVehicleWheels": [2, 3, 4],
+                    "forVehicleWheels": [2, 3],
                     "defaultTestCode": "ea2",
                     "linkedTestCode": null,
                     "forProvisionalStatus": true


### PR DESCRIPTION
## MSVA Contingency Test With 'Number of Wheels' = 3 Producing Internal Server Error When Submitting a Test Record

When a user is creating a contingency test for a motorcycle and the technical record of the motorcycle has both Vehicle class = Motorbikes over 200cc or with a sidecar & Number of wheels = 3  then VTM is producing a "500 HTTP response Internal Server" error message when trying to submit the required test record info.

As part of this change, updates test-type taxonomy to allow 2 or 3 wheels driven for ea2

[CB2-11215](https://dvsa.atlassian.net/browse/CB2-11215)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
